### PR TITLE
Fix iOS keyboard behavior.

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -60,6 +60,9 @@
       <preference name="StatusBarBackgroundColor" value="#000000" />
       <preference name="StatusBarStyle" value="lightcontent" />
 
+      <preference name="DisallowOverscroll" value="true" />
+      <preference name="KeyboardShrinksView" value="true" />
+      <preference name="HideKeyboardFormAccessoryBar" value="true" />
 
     </platform>
 </widget>


### PR DESCRIPTION
Now keyboard won't scroll the web view, instead it's shrunk so you still can see top bar when the keyboard is open. I also disabled accessory bar (one with arrows and "done" on it).

<img width="487" alt="screen shot 2016-10-09 at 17 15 25" src="https://cloud.githubusercontent.com/assets/1065521/19221057/fcc2c0ca-8e43-11e6-8288-60b3f47dd696.png">

It also fixes the issue where if there are few messages, and you open keyboard to type a reply to a message, the web view scrolls up and as such all messages are hidden.

This requires a simple change to glowing-bear repo:

```diff
diff --git a/css/glowingbear.css b/css/glowingbear.css
index 647233d..f2a0b53 100644
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -345,8 +345,8 @@ td.time {
 }

 .footer {
-    position: fixed;
-    bottom: 0;
+    position: relative;
+    bottom: 35px;
     height: 35px;
     width: 100%;
     -webkit-transition:0.2s ease-in-out all;
```

otherwise after opening the keyboard, the input field jumps to the top like this: https://i.imgur.com/cIQe7WY.png (no idea why)